### PR TITLE
Fixes to linux glog build.

### DIFF
--- a/src/demangle.h
+++ b/src/demangle.h
@@ -77,7 +77,7 @@ _START_GOOGLE_NAMESPACE_
 // Demangle "mangled".  On success, return true and write the
 // demangled symbol name to "out".  Otherwise, return false.
 // "out" is modified even if demangling is unsuccessful.
-bool Demangle(const char *mangled, char *out, int out_size);
+bool GOOGLE_GLOG_DLL_DECL Demangle(const char *mangled, char *out, int out_size);
 
 _END_GOOGLE_NAMESPACE_
 

--- a/src/demangle.h
+++ b/src/demangle.h
@@ -77,7 +77,7 @@ _START_GOOGLE_NAMESPACE_
 // Demangle "mangled".  On success, return true and write the
 // demangled symbol name to "out".  Otherwise, return false.
 // "out" is modified even if demangling is unsuccessful.
-bool GOOGLE_GLOG_DLL_DECL Demangle(const char *mangled, char *out, int out_size);
+bool Demangle(const char *mangled, char *out, int out_size);
 
 _END_GOOGLE_NAMESPACE_
 

--- a/src/glog/logging.h.in
+++ b/src/glog/logging.h.in
@@ -510,6 +510,8 @@ DECLARE_bool(stop_logging_if_full_disk);
 // specified by argv0 in log outputs.
 GOOGLE_GLOG_DLL_DECL void InitGoogleLogging(const char* argv0);
 
+GOOGLE_GLOG_DLL_DECL bool IsGoogleLoggingInitialized();
+
 // Shutdown google's logging library.
 GOOGLE_GLOG_DLL_DECL void ShutdownGoogleLogging();
 
@@ -1247,6 +1249,9 @@ public:
   static int64 num_messages(int severity);
 
   struct LogMessageData;
+
+protected:
+  time_t timestamp() const;
 
 private:
   // Fully internal SendMethod cases:

--- a/src/stacktrace_generic-inl.h
+++ b/src/stacktrace_generic-inl.h
@@ -38,7 +38,7 @@
 _START_GOOGLE_NAMESPACE_
 
 // If you change this function, also change GetStackFrames below.
-int GetStackTrace(void** result, int max_depth, int skip_count) {
+size_t GetStackTrace(void** result, size_t max_depth, int skip_count) {
   static const int kStackLength = 64;
   void * stack[kStackLength];
   int size;


### PR DESCRIPTION
I'm not certain about the change to demangle.h here, doesn't feel like the right fix. Removing GOOGLE_GLOG_DLL_DECL does allow it to build though.
