### PR TITLE
Use CMake instead of autotools for *nix build

### DIFF
--- a/principia_make.sh
+++ b/principia_make.sh
@@ -1,5 +1,4 @@
-mkdir -p build
-pushd build
+pushd src
 cmake \
     -DCMAKE_C_COMPILER:FILEPATH="$(which clang)" \
     -DCMAKE_CXX_COMPILER:FILEPATH="$(which clang++)" \
@@ -7,6 +6,7 @@ cmake \
     -DCMAKE_CXX_FLAGS="${CXX_FLAGS}" \
     -DWITH_GFLAGS=OFF \
     -DBUILD_SHARED_LIBRARIES=OFF \
+    -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY:FILEPATH=../.libs \
     ..
 make -j8
 popd

--- a/principia_make.sh
+++ b/principia_make.sh
@@ -2,8 +2,8 @@ pushd src
 cmake \
     -DCMAKE_C_COMPILER:FILEPATH="$(which clang)" \
     -DCMAKE_CXX_COMPILER:FILEPATH="$(which clang++)" \
-    -DCMAKE_C_FLAGS="${C_FLAGS}" \
-    -DCMAKE_CXX_FLAGS="${CXX_FLAGS}" \
+    -DCMAKE_C_FLAGS="${C_FLAGS?}" \
+    -DCMAKE_CXX_FLAGS="${CXX_FLAGS?}" \
     -DWITH_GFLAGS=OFF \
     -DBUILD_SHARED_LIBRARIES=OFF \
     -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY:FILEPATH=../.libs \

--- a/principia_make.sh
+++ b/principia_make.sh
@@ -1,9 +1,12 @@
-./autogen.sh
-./configure \
-    CC=clang \
-    CXX=clang++ \
-    CFLAGS="${C_FLAGS?}" \
-    CXXFLAGS="${CXX_FLAGS?}" \
-    LDFLAGS="${LD_FLAGS?}" \
-    LIBS="-lc++ -lc++abi"
+mkdir -p build
+pushd build
+cmake \
+    -DCMAKE_C_COMPILER:FILEPATH="$(which clang)" \
+    -DCMAKE_CXX_COMPILER:FILEPATH="$(which clang++)" \
+    -DCMAKE_C_FLAGS="${C_FLAGS}" \
+    -DCMAKE_CXX_FLAGS="${CXX_FLAGS}" \
+    -DWITH_GFLAGS=OFF \
+    -DBUILD_SHARED_LIBRARIES=OFF \
+    ..
 make -j8
+popd


### PR DESCRIPTION
The autotools build will pick up the system gflags install if present
and compile in a dependency on gflags. This later causes bin/tools to
fail to link since Principia does not depend on gflags and so does not
pass -lgflags to the link command [0].

Unfortunately, there is no way to force glog to not build with gflags
when using autotools. --without-gflags gets translated to
--with-gflags=no, and that gets interpreted as requesting a build with
gflags where the gflags lib is located at no/lib [1], causing glog to
fail to build.

Luckily, the CMake build does provide a way to build without gflags even
if it is installed, and the translation from autotools to CMake is
fairly straightforward. LDFLAGS and LIBS are dropped because a static
library is generated and the linker flags specified in LDFLAGS and LIBS
are not used by ar.

[0]:

    clang++ -std=c++1z -stdlib=libc++ -O3 -g -fPIC -fexceptions -ferror-limit=1000 -fno-omit-frame-pointer -Wall -Wpedantic -Wno-char-subscripts -Wno-gnu-anonymous-struct -Wno-gnu-zero-variadic-macro-arguments -Wno-nested-anon-types -Wno-unknown-pragmas -DPROJECT_DIR='std::filesystem::path("ksp_plugin_adapter/")' -DSOLUTION_DIR='std::filesystem::path("./")' -DTEMP_DIR='std::filesystem::path("/tmp")' -DNDEBUG -mmacosx-version-min=10.12 -arch x86_64 -D_LIBCPP_STD_VER=16 obj/tools/generate_configuration.o obj/tools/generate_kopernicus.o obj/tools/generate_profiles.o obj/tools/journal_proto_processor.o obj/tools/main.o obj/serialization/astronomy.pb.o obj/serialization/geometry.pb.o obj/serialization/integrators.pb.o obj/serialization/journal.pb.o obj/serialization/ksp_plugin.pb.o obj/serialization/numerics.pb.o obj/serialization/physics.pb.o obj/serialization/quantities.pb.o obj/serialization/testing_utilities.pb.o obj/numerics/cbrt.o obj/numerics/elliptic_functions.o obj/numerics/elliptic_integrals.o obj/numerics/fast_sin_cos_2π.o obj/base/version.generated.o deps/protobuf/src/.libs/libprotobuf.a deps/gipfeli/libgipfeli.a deps/abseil-cpp/absl/strings/libabsl_strings.a deps/abseil-cpp/absl/synchronization/libabsl_synchronization.a deps/abseil-cpp/absl/time/libabsl_*.a deps/abseil-cpp/absl/debugging/libabsl_*.a deps/abseil-cpp/absl/numeric/libabsl_*.a deps/abseil-cpp/absl/base/libabsl_*.a deps/zfp/build/lib/libzfp.a deps/glog/.libs//libglog.a -lpthread -lc++ -lc++abi -o bin/tools
    Undefined symbols for architecture x86_64:
      "google::FlagRegisterer::FlagRegisterer<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >(char const*, char const*, char const*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >*)", referenced from:
          __GLOBAL__sub_I_logging.cc in libglog.a(libglog_la-logging.o)
          __GLOBAL__sub_I_vlog_is_on.cc in libglog.a(libglog_la-vlog_is_on.o)
      "google::FlagRegisterer::FlagRegisterer<bool>(char const*, char const*, char const*, bool*, bool*)", referenced from:
          __GLOBAL__sub_I_logging.cc in libglog.a(libglog_la-logging.o)
          __GLOBAL__sub_I_utilities.cc in libglog.a(libglog_la-utilities.o)
      "google::FlagRegisterer::FlagRegisterer<int>(char const*, char const*, char const*, int*, int*)", referenced from:
          __GLOBAL__sub_I_logging.cc in libglog.a(libglog_la-logging.o)
          __GLOBAL__sub_I_vlog_is_on.cc in libglog.a(libglog_la-vlog_is_on.o)
    ld: symbol(s) not found for architecture x86_64
    clang: error: linker command failed with exit code 1 (use -v to see invocation)
    make: *** [bin/tools] Error 1

[1]:

    /bin/sh ./libtool  --tag=CXX   --mode=link g++  -Ino/include  -Wall -Wwrite-strings -Woverloaded-virtual -Wno-sign-compare  -DNO_FRAME_POINTER  -DNDEBUG -g -O2    -o libglog.la -rpath /usr/local/lib  src/libglog_la-logging.lo src/libglog_la-raw_logging.lo src/libglog_la-vlog_is_on.lo src/libglog_la-utilities.lo src/libglog_la-demangle.lo src/libglog_la-symbolize.lo src/libglog_la-signalhandler.lo   -Lno/lib -lgflags  -lpthread
    ./libtool: line 7483: cd: no/lib: No such file or directory
    libtool:   error: cannot determine absolute directory name of 'no/lib'
    make: *** [libglog.la] Error 1